### PR TITLE
sirokumaのアニメーションに関して、操作が60秒無かった時のみ眠り、起きるときは動けるようになるまで時間ができるように設定、iceb…

### DIFF
--- a/New Unity Project/Assets/Pikatan/Script/Gimmicks/IceBreak/IceBreak.cs
+++ b/New Unity Project/Assets/Pikatan/Script/Gimmicks/IceBreak/IceBreak.cs
@@ -17,6 +17,7 @@ public class IceBreak : MonoBehaviour
     private ParticleSystem particle;
     private bool isChange = false;
     private Transform tr;
+    private Vector3 vec3;
     private int num;
     void Start()
     {
@@ -43,16 +44,30 @@ public class IceBreak : MonoBehaviour
 
     private void FixedUpdate()
     {
+
         if (num == 0)
         {
-            tr.position = new Vector3(tr.position.x + countTime / 3.0f, tr.position.y, tr.position.z);
-            num++;
+            vec3 = tr.position;
         }
-        else
+
+        if (countTime < 2.95f)
         {
-            tr.position = new Vector3(tr.position.x - countTime / 3.0f, tr.position.y, tr.position.z);
-            num = 0;
+            if (num % 2 == 0)
+            {
+                tr.position = new Vector3(tr.position.x + countTime / 3.0f, tr.position.y, tr.position.z);
+                num++;
+            }
+            else
+            {
+                tr.position = new Vector3(tr.position.x - countTime / 3.0f, tr.position.y, tr.position.z);
+                num++;
+            }
         }
+        else if (countTime >= 2.95f)
+        {
+            tr.position = vec3;
+        }
+
     }
 
     private void BreakIce()

--- a/New Unity Project/Assets/Pikatan/Script/Player/PlayerManager.cs
+++ b/New Unity Project/Assets/Pikatan/Script/Player/PlayerManager.cs
@@ -34,6 +34,8 @@ public class PlayerManager : MonoBehaviour
     private CameraController cc;
     private float stoptime;
     private bool flag=false;
+    private bool sleep = false;
+    private Animator anim;
     public int penguinNum { get; private set; } = 0;
     #endregion
 
@@ -56,6 +58,7 @@ public class PlayerManager : MonoBehaviour
         pac = GetComponent<PlayerAnimationController>();
         poseCtrl = GameObject.Find("Pose").GetComponent<PoseController>();
         cc = GameObject.Find("Main Camera").GetComponent<CameraController>();
+        anim = GetComponent<Animator>();
     }
 
     void Update()
@@ -89,23 +92,28 @@ public class PlayerManager : MonoBehaviour
         {
             pac.EndSleep();
             flag = false;
-            isMove = true;
-            //rb.AddForce(moveDirection);
             
-            rb.velocity = moveDirection * speed;
-            Turn();
-            if(Mathf.Abs(moveDirection.x) >= 0.05f)
+            if (sleep&&anim.GetCurrentAnimatorStateInfo(0).IsName("待機"))
             {
-                if (!isInWater)
+                sleep = false;
+            }
+            //rb.AddForce(moveDirection);
+            if (!sleep) {
+                isMove = true;
+                rb.velocity = moveDirection * speed;
+                Turn();
+                if (Mathf.Abs(moveDirection.x) >= 0.05f)
                 {
-                    pac.StartWalk();
-                }
-                else
-                {
-                    pac.StartSwim();
+                    if (!isInWater)
+                    {
+                        pac.StartWalk();
+                    }
+                    else
+                    {
+                        pac.StartSwim();
+                    }
                 }
             }
-
         }
         //入力がないとき
         else
@@ -120,8 +128,9 @@ public class PlayerManager : MonoBehaviour
                 stoptime = Time.time;
                 flag = true;
             }
-            if (Time.time - stoptime > 5.0f)
+            if (Time.time - stoptime > 60.0f)
             {
+                sleep = true;
                 pac.Sleep();
             }
         }

--- a/New Unity Project/Assets/iso/Model/animation/Controller/sirokumaAnima.controller
+++ b/New Unity Project/Assets/iso/Model/animation/Controller/sirokumaAnima.controller
@@ -418,7 +418,7 @@ AnimatorStateMachine:
     m_Position: {x: 80, y: 50, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -1162420401209560215}
-    m_Position: {x: 370, y: 280, z: 0}
+    m_Position: {x: 310, y: 280, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -2435411785540494963}
     m_Position: {x: 240, y: -50, z: 0}
@@ -430,7 +430,7 @@ AnimatorStateMachine:
     m_Position: {x: 150, y: 230, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -4631027785487207946}
-    m_Position: {x: 540, y: 340, z: 0}
+    m_Position: {x: 570, y: 280, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 8428917386558174677}
     m_Position: {x: 960, y: 70, z: 0}


### PR DESCRIPTION
…reakの振動を追加したことで割れる際にplayerが上空にふきとばないように調整